### PR TITLE
Add CNAME for custom domain unopengis.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+unopengis.org


### PR DESCRIPTION
This will enable the website to be directly https://unopengis.org avoiding the current https error before the redirect to github.io.

You will need to add the a CNAME entry on the DNS zone pointing to unopengis.github.io